### PR TITLE
Expand BungeeCord support to 1.16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiveMotdManager
 
-LiveMotdManager is a multi-platform Minecraft plugin providing a dynamic server list MOTD. It supports Spigot/Paper/Purpur/Folia servers and BungeeCord/Waterfall/Velocity proxies. The plugin changes MOTD based on time, player count, TPS and more. Weather and Discord integrations are included.
+LiveMotdManager is a multi-platform Minecraft plugin providing a dynamic server list MOTD. It supports Spigot/Paper/Purpur/Folia servers and BungeeCord/Waterfall (1.16+) / Velocity proxies. The plugin changes MOTD based on time, player count, TPS and more. Weather and Discord integrations are included.
 
 ## Building
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -16,7 +16,8 @@
     <dependency>
       <groupId>net.md-5</groupId>
       <artifactId>bungeecord-api</artifactId>
-      <version>1.20-R0.1-SNAPSHOT</version>
+      <!-- Compile against 1.16 API for compatibility with BungeeCord/Waterfall 1.16+ -->
+      <version>1.16-R0.4</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- compile Bungee module against 1.16 API for wider BungeeCord/Waterfall compatibility
- document BungeeCord/Waterfall 1.16+ support in README

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68927940bd9c832aac8e398a182e4788