### PR TITLE
Fix config loading for hyphenated keys

### DIFF
--- a/core/src/main/java/com/livemotdmanager/core/ConfigLoader.java
+++ b/core/src/main/java/com/livemotdmanager/core/ConfigLoader.java
@@ -2,6 +2,10 @@ package com.livemotdmanager.core;
 
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -15,9 +19,30 @@ public final class ConfigLoader {
 
     public static MotdConfig load(InputStream in) {
         LoaderOptions options = new LoaderOptions();
-        Yaml yaml = new Yaml(options);
+        Constructor constructor = new Constructor(MotdConfig.class, options);
+        PropertyUtils utils = new PropertyUtils() {
+            @Override
+            public Property getProperty(Class<?> type, String name, BeanAccess bAccess) {
+                // convert kebab-case (update-interval-minutes) to camelCase
+                StringBuilder sb = new StringBuilder();
+                boolean upper = false;
+                for (char c : name.toCharArray()) {
+                    if (c == '-') {
+                        upper = true;
+                    } else {
+                        sb.append(upper ? Character.toUpperCase(c) : c);
+                        upper = false;
+                    }
+                }
+                return super.getProperty(type, sb.toString(), bAccess);
+            }
+        };
+        utils.setSkipMissingProperties(true);
+        constructor.setPropertyUtils(utils);
+        Yaml yaml = new Yaml(constructor);
+        yaml.setBeanAccess(BeanAccess.FIELD);
         try (InputStreamReader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
-            MotdConfig cfg = yaml.loadAs(reader, MotdConfig.class);
+            MotdConfig cfg = yaml.load(reader);
             if (cfg == null) cfg = new MotdConfig();
             return cfg;
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Allow YAML keys like `update-interval-minutes` to load into config objects
- Ignore unknown YAML properties instead of failing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68927cd08af4832a9f8db667033fcfda